### PR TITLE
#17: add custom picker view

### DIFF
--- a/everyBody/everyBody-iOS.xcodeproj/project.pbxproj
+++ b/everyBody/everyBody-iOS.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		AA5B85DF27170F27002276C3 /* UINavigationController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5B85DE27170F27002276C3 /* UINavigationController+Extensions.swift */; };
 		AA5B85E127171072002276C3 /* TabbarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5B85E027171072002276C3 /* TabbarViewController.swift */; };
 		AA5B85E327173DC0002276C3 /* ViewFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5B85E227173DC0002276C3 /* ViewFinder.swift */; };
+		AA7366512746BD53002B726D /* DateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7366502746BD53002B726D /* DateViewModel.swift */; };
+		AA73665327485C3D002B726D /* String+2DigitFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA73665227485C3D002B726D /* String+2DigitFormat.swift */; };
 		AA7E0A3626FB0A6100106DC2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7E0A3526FB0A6100106DC2 /* AppDelegate.swift */; };
 		AA7E0A3826FB0A6100106DC2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7E0A3726FB0A6100106DC2 /* SceneDelegate.swift */; };
 		AA7E0A3A26FB0A6100106DC2 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7E0A3926FB0A6100106DC2 /* ViewController.swift */; };
@@ -42,6 +44,7 @@
 		AA95911F27445CD0007772BD /* className.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA95911E27445CD0007772BD /* className.swift */; };
 		AA9591212744EDDC007772BD /* UICollectionView+Generic.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9591202744EDDC007772BD /* UICollectionView+Generic.swift */; };
 		AA95912327458F92007772BD /* UIVIew+renderToImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA95912227458F92007772BD /* UIVIew+renderToImageView.swift */; };
+		AA9591252746ABE2007772BD /* NBDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9591242746ABE2007772BD /* NBDatePicker.swift */; };
 		AA9A41472715EC2C002BBE15 /* Camera.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9A41462715EC2C002BBE15 /* Camera.swift */; };
 		AABEA2DD273C4A3300A06A8C /* Gilroy-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AABEA2D7273C4A3300A06A8C /* Gilroy-Light.ttf */; };
 		AABEA2DE273C4A3300A06A8C /* Pretendard-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AABEA2D8273C4A3300A06A8C /* Pretendard-Bold.ttf */; };
@@ -107,6 +110,8 @@
 		AA5B85DE27170F27002276C3 /* UINavigationController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Extensions.swift"; sourceTree = "<group>"; };
 		AA5B85E027171072002276C3 /* TabbarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarViewController.swift; sourceTree = "<group>"; };
 		AA5B85E227173DC0002276C3 /* ViewFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewFinder.swift; sourceTree = "<group>"; };
+		AA7366502746BD53002B726D /* DateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateViewModel.swift; sourceTree = "<group>"; };
+		AA73665227485C3D002B726D /* String+2DigitFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+2DigitFormat.swift"; sourceTree = "<group>"; };
 		AA7E0A3226FB0A6100106DC2 /* everyBody-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "everyBody-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA7E0A3526FB0A6100106DC2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AA7E0A3726FB0A6100106DC2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -131,6 +136,7 @@
 		AA95911E27445CD0007772BD /* className.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = className.swift; sourceTree = "<group>"; };
 		AA9591202744EDDC007772BD /* UICollectionView+Generic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Generic.swift"; sourceTree = "<group>"; };
 		AA95912227458F92007772BD /* UIVIew+renderToImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIVIew+renderToImageView.swift"; sourceTree = "<group>"; };
+		AA9591242746ABE2007772BD /* NBDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NBDatePicker.swift; sourceTree = "<group>"; };
 		AA9A41462715EC2C002BBE15 /* Camera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Camera.swift; sourceTree = "<group>"; };
 		AABEA2D7273C4A3300A06A8C /* Gilroy-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Gilroy-Light.ttf"; sourceTree = "<group>"; };
 		AABEA2D8273C4A3300A06A8C /* Pretendard-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.ttf"; sourceTree = "<group>"; };
@@ -213,6 +219,7 @@
 				AA95911E27445CD0007772BD /* className.swift */,
 				AA9591202744EDDC007772BD /* UICollectionView+Generic.swift */,
 				AA95912227458F92007772BD /* UIVIew+renderToImageView.swift */,
+				AA73665227485C3D002B726D /* String+2DigitFormat.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -380,6 +387,7 @@
 				AAC7ACB9272D5E3E00B2BE1E /* BottomSheetView.swift */,
 				AAC7ACDF272D947000B2BE1E /* CustomSwitch.swift */,
 				AAC7ACE1272DBEDC00B2BE1E /* ToastView.swift */,
+				AA9591242746ABE2007772BD /* NBDatePicker.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -399,6 +407,7 @@
 				AAC7ACA62729E91400B2BE1E /* CameraViewModel.swift */,
 				AAC7ACBD272D7DF400B2BE1E /* PoseViewModel.swift */,
 				AABEA2E6273C585C00A06A8C /* AlbumViewModel.swift */,
+				AA7366502746BD53002B726D /* DateViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -685,6 +694,7 @@
 				AA95911827443FB9007772BD /* UIViewController+hideKeyboard.swift in Sources */,
 				AAC7ACB22729F2B100B2BE1E /* Fonts.swift in Sources */,
 				AAC7AD182735A11C00B2BE1E /* AppDate.swift in Sources */,
+				AA9591252746ABE2007772BD /* NBDatePicker.swift in Sources */,
 				AA7E0A4026FB0A6100106DC2 /* everyBody_iOS.xcdatamodeld in Sources */,
 				AA7E0A5A26FB0BAD00106DC2 /* CellSample.swift in Sources */,
 				AAC7AD242737B6CB00B2BE1E /* FolderSelectionViewController.swift in Sources */,
@@ -705,6 +715,7 @@
 				AAC7AD282737B9E900B2BE1E /* SelectedView.swift in Sources */,
 				AA95911F27445CD0007772BD /* className.swift in Sources */,
 				AAC7ACE2272DBEDC00B2BE1E /* ToastView.swift in Sources */,
+				AA7366512746BD53002B726D /* DateViewModel.swift in Sources */,
 				AABEA2E5273C578E00A06A8C /* Album.swift in Sources */,
 				AAC7ACBA272D5E3E00B2BE1E /* BottomSheetView.swift in Sources */,
 				AAC7ACB4272D474E00B2BE1E /* CaptureButton.swift in Sources */,
@@ -719,6 +730,7 @@
 				FCB27001273532C200D8B056 /* AlbumViewController.swift in Sources */,
 				AABEA2E7273C585C00A06A8C /* AlbumViewModel.swift in Sources */,
 				AAC7ACA32729DFC700B2BE1E /* BaseViewController.swift in Sources */,
+				AA73665327485C3D002B726D /* String+2DigitFormat.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/everyBody/everyBody-iOS/Source/Camera/Model/AppDate.swift
+++ b/everyBody/everyBody-iOS/Source/Camera/Model/AppDate.swift
@@ -76,21 +76,34 @@ class AppDate {
         return hour
     }
     
+    func getMinute() -> Int {
+        guard let minute = Int(self.getDateComponent(with: "mm")) else { return 0 }
+        return minute
+    }
+    
     func getWeekday() -> String {
         guard let weekday = self.weekday else { return "" }
         return weekday
     }
 
     func getDayToString() -> String {
-        return "\(self.getDay())"
+        return self.getDateComponent(with: "dd")
     }
     
     func getMonthToString() -> String {
-        return "\(self.getMonth())"
+        return self.getDateComponent(with: "MM")
     }
     
     func getYearToString() -> String {
         return "\(self.getYear())"
+    }
+    
+    func getHourToString() -> String {
+        return self.getDateComponent(with: "HH")
+    }
+    
+    func getMinuteToString() -> String {
+        return self.getDateComponent(with: "mm")
     }
     
     private func getDateComponent(with format: String) -> String {

--- a/everyBody/everyBody-iOS/Source/Camera/Model/Camera.swift
+++ b/everyBody/everyBody-iOS/Source/Camera/Model/Camera.swift
@@ -39,9 +39,9 @@ class Camera: NSObject {
     
     var outputImage = UIImage()
     var outputImageRelay = PublishRelay<UIImage>()
-    
     var creationDate = PublishSubject<String>()
     var meridiemTime = PublishSubject<String>()
+    var fullDate = PublishSubject<String>()
     
     // MARK: - Initalizer
     
@@ -130,13 +130,8 @@ class Camera: NSObject {
     }
     
     func savePicture(pictureData: Data) {
-
         let image = UIImage(data: pictureData)!
-        
-        outputImage = image
-        outputImageRelay.accept(outputImage)
-
-        //        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil) // 앨범에 이미지 저장
+        outputImageRelay.accept(image)
     }
 
     // MARK: - Actions

--- a/everyBody/everyBody-iOS/Source/Camera/ViewControllers/CameraOutputViewController.swift
+++ b/everyBody/everyBody-iOS/Source/Camera/ViewControllers/CameraOutputViewController.swift
@@ -29,6 +29,7 @@ class CameraOutputViewController: BaseViewController {
     }
     private let contentsView = UIView()
     private let containerView = UIView()
+    
     private let photoOutputImageView = UIImageView().then {
         $0.backgroundColor = .black
         $0.contentMode = .scaleAspectFill
@@ -277,23 +278,23 @@ extension CameraOutputViewController: NBSegmentedControlDelegate {
         }
     }
     
-    func hidePartComponents() {
+    private func hidePartComponents() {
         partSegmentedControl.isHidden = true
         photoTimeSegemntedControl.isHidden = false
         descriptionLabel.isHidden = true
     }
     
-    func showPartComponents() {
+    private func showPartComponents() {
         partSegmentedControl.isHidden = false
         photoTimeSegemntedControl.isHidden = true
         descriptionLabel.isHidden = false
     }
     
-    func hidePhotoComponents() {
+    private func hidePhotoComponents() {
         pickerView.isHidden = true
     }
     
-    func showPhotoComponents() {
+    private func showPhotoComponents() {
         pickerView.isHidden = false
     }
 }

--- a/everyBody/everyBody-iOS/Source/Camera/ViewControllers/CameraOutputViewController.swift
+++ b/everyBody/everyBody-iOS/Source/Camera/ViewControllers/CameraOutputViewController.swift
@@ -11,7 +11,7 @@ import RxCocoa
 import RxSwift
 
 class CameraOutputViewController: BaseViewController {
-
+    
     enum Part: Int {
         case whole = 0, upper, lower
     }
@@ -25,6 +25,7 @@ class CameraOutputViewController: BaseViewController {
     private let scrollView = UIScrollView().then {
         $0.backgroundColor = .white
         $0.showsVerticalScrollIndicator = false
+        $0.isScrollEnabled = false
     }
     private let contentsView = UIView()
     private let containerView = UIView()
@@ -55,11 +56,21 @@ class CameraOutputViewController: BaseViewController {
         $0.font = .nbFont(ofSize: 24, weight: .bold, type: .gilroy)
         $0.textColor = .white
     }
+    private lazy var pickerView = NBDatePicker().then {
+        $0.isUserInteractionEnabled = false
+        $0.isHidden = true
+        $0.delegate = self
+    }
     
     // MARK: - Properties
     
     private var cameraViewModel = CameraViewModel()
     private let camera = Camera.shared
+    private var metaDataArray: [String] = [] {
+        didSet {
+            if metaDataArray.count == 6 { pickerView.setMetaDataTime(dataArray: metaDataArray) }
+        }
+    }
     
     // MARK: - View Life Cyle
     
@@ -91,8 +102,8 @@ class CameraOutputViewController: BaseViewController {
     
     private func initSegementData() {
         let segmentControls = [partAndTimeSegmentedControl: ["부위 선택", "시간 입력"],
-                               photoTimeSegemntedControl: ["사진 시간", "현재 시간", "직접 입력"],
-                               partSegmentedControl: ["전신", "상체", "하체"]]
+                                 photoTimeSegemntedControl: ["사진 시간", "현재 시간", "직접 입력"],
+                                      partSegmentedControl: ["전신", "상체", "하체"]]
         
         for segmentControl in segmentControls {
             for (index, title) in segmentControl.value.enumerated() {
@@ -112,6 +123,18 @@ class CameraOutputViewController: BaseViewController {
         
         cameraViewModel.meridiemTime
             .bind(to: meridiemLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        cameraViewModel.creationTime
+            .subscribe {
+                self.metaDataArray = $0.split(separator: ".").map { String($0) }
+            }
+            .disposed(by: disposeBag)
+        
+        camera.meridiemTime
+            .subscribe {
+                self.metaDataArray += $0.split(separator: ":").map { String($0) }
+            }
             .disposed(by: disposeBag)
     }
     
@@ -140,7 +163,8 @@ extension CameraOutputViewController {
                                  partAndTimeSegmentedControl,
                                  partSegmentedControl,
                                  descriptionLabel,
-                                 photoTimeSegemntedControl)
+                                 photoTimeSegemntedControl,
+                                 pickerView)
         containerView.addSubviews(photoOutputImageView, dateTimeLabel, meridiemLabel)
         scrollView.addSubview(contentsView)
         view.addSubview(scrollView)
@@ -196,8 +220,15 @@ extension CameraOutputViewController {
             $0.bottom.equalTo(photoOutputImageView.snp.bottom).inset(12)
         }
         
+        pickerView.snp.makeConstraints {
+            $0.top.equalTo(photoTimeSegemntedControl.snp.bottom).offset(22)
+            $0.width.equalTo(300)
+            $0.height.equalTo(100)
+            $0.centerX.equalToSuperview()
+        }
+        
     }
-
+    
 }
 
 // MARK: - NBSegementedControlDelegate
@@ -208,19 +239,26 @@ extension CameraOutputViewController: NBSegmentedControlDelegate {
         if segmentControl == partAndTimeSegmentedControl {
             switch index {
             case 0:
-                hidePartComponents()
-            case 1:
                 showPartComponents()
+                hidePhotoComponents()
+            case 1:
+                hidePartComponents()
+                showPhotoComponents()
             default:
                 return
             }
         } else if segmentControl == photoTimeSegemntedControl {
             switch Time.init(rawValue: index) {
             case .photo:
+                pickerView.setMetaDataTime(dataArray: metaDataArray)
+                pickerView.isUserInteractionEnabled = false
                 return
             case .current:
+                pickerView.setCurrnetTime()
+                pickerView.isUserInteractionEnabled = false
                 return
             case .custom:
+                pickerView.isUserInteractionEnabled = true
                 return
             default:
                 return
@@ -238,16 +276,40 @@ extension CameraOutputViewController: NBSegmentedControlDelegate {
             }
         }
     }
-        
+    
     func hidePartComponents() {
+        partSegmentedControl.isHidden = true
+        photoTimeSegemntedControl.isHidden = false
+        descriptionLabel.isHidden = true
+    }
+    
+    func showPartComponents() {
         partSegmentedControl.isHidden = false
         photoTimeSegemntedControl.isHidden = true
         descriptionLabel.isHidden = false
     }
     
-    func showPartComponents() {
-        partSegmentedControl.isHidden = true
-        photoTimeSegemntedControl.isHidden = false
-        descriptionLabel.isHidden = true
+    func hidePhotoComponents() {
+        pickerView.isHidden = true
     }
+    
+    func showPhotoComponents() {
+        pickerView.isHidden = false
+    }
+}
+
+extension CameraOutputViewController: DatePickerDelegate {
+    
+    func pickerViewSelected(_ dateArray: [String]) {
+        dateTimeLabel.text = "\(dateArray[0]).\(dateArray[1]).\(dateArray[2])"
+        
+        guard let hour = Int(dateArray[3]) else { return }
+        if hour < 12 {
+            meridiemLabel.text = "AM \(dateArray[3]):\(dateArray[4])"
+        } else {
+            let hourString = "\(hour - 12)".convertTo2Digit()
+            meridiemLabel.text = "PM \(hourString):\(dateArray[4])"
+        }
+    }
+    
 }

--- a/everyBody/everyBody-iOS/Source/Camera/ViewModels/CameraViewModel.swift
+++ b/everyBody/everyBody-iOS/Source/Camera/ViewModels/CameraViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 import RxSwift
 
 struct CameraViewModel {
+    
     var camera = Camera.shared
     var creationTime: PublishSubject<String> {
         return camera.creationDate
@@ -24,4 +25,5 @@ struct CameraViewModel {
             }
         }
     }
+    
 }

--- a/everyBody/everyBody-iOS/Source/Camera/ViewModels/DateViewModel.swift
+++ b/everyBody/everyBody-iOS/Source/Camera/ViewModels/DateViewModel.swift
@@ -1,0 +1,80 @@
+//
+//  DateViewModel.swift
+//  everyBody-iOS
+//
+//  Created by 윤예지 on 2021/11/19.
+//
+
+import Foundation
+
+import RxSwift
+
+enum Month: Int {
+    case jan = 1, feb, mar, apr, may, june, july, aug, sep, oct, nov, dec
+    
+    func toString() -> String {
+        return "\(self)".capitalized
+    }
+    
+    func toNumberMonth() -> String {
+        switch self {
+        case .jan:
+            return "01"
+        case .feb:
+            return "02"
+        case .mar:
+            return "03"
+        case .apr:
+            return "04"
+        case .may:
+            return "05"
+        case .june:
+            return "06"
+        case .july:
+            return "07"
+        case .aug:
+            return "08"
+        case .sep:
+            return "09"
+        case .oct:
+            return "10"
+        case .nov:
+            return "11"
+        case .dec:
+            return "12"
+        }
+    }
+}
+
+struct DateViewModel {
+    
+    private let camera = Camera.shared
+    
+    let currentDate = AppDate()
+    
+    var yearList: [String] {
+        return (2000...currentDate.getYear()).map {
+            String($0)
+        }
+    }
+    
+    var monthList: [Month] {
+        return [.jan, .feb, .mar, .apr, .may, .june, .july, .aug, .sep, .oct, .nov, .dec]
+    }
+    
+    var dayList: [[String]] {
+        return [(1...31).map { String($0) },
+                (1...30).map { String($0) },
+                (1...29).map { String($0) },
+                (1...28).map { String($0) }]
+    }
+    
+    var hourList: [String] {
+        return (1...24).map { String($0) }
+    }
+    
+    var minuteList: [String] {
+        return (0...59).map { String($0) }
+    }
+
+}

--- a/everyBody/everyBody-iOS/Source/Camera/Views/NBDatePicker.swift
+++ b/everyBody/everyBody-iOS/Source/Camera/Views/NBDatePicker.swift
@@ -164,7 +164,9 @@ extension NBDatePicker: UIPickerViewDelegate {
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         switch pickerView {
         case yearPickerView:
+            guard let month = Int(selectedMonth) else { return }
             selectedYear = dateViewModel.yearList[row]
+            setDayDate(with: Month.init(rawValue: month) ?? .jan)
         case monthPickerView:
             setDayDate(with: dateViewModel.monthList[row])
             selectedMonth = dateViewModel.monthList[row].toNumberMonth()

--- a/everyBody/everyBody-iOS/Source/Camera/Views/NBDatePicker.swift
+++ b/everyBody/everyBody-iOS/Source/Camera/Views/NBDatePicker.swift
@@ -89,7 +89,7 @@ class NBDatePicker: UIView {
         }
         
         colonLabel.snp.makeConstraints {
-            $0.leading.equalTo(hourPickerView.snp.trailing).offset(-7)
+            $0.leading.equalTo(hourPickerView.snp.trailing).offset(-8)
             $0.top.equalTo(36)
         }
     }
@@ -104,14 +104,27 @@ class NBDatePicker: UIView {
     }
     
     private func setDayDate(with month: Month) {
+        guard let day = Int(selectedDay) else { return }
         switch month {
         case .jan, .mar, .may, .july, .aug, .oct, .dec:
+            // 1, 3, 5, 7, 8, 10, 12월은 31일.
             dayType = 0
         case .feb:
+            // 2월은 윤년 여부에 따라 29일 혹은 28일
+            // 31일 혹은 30일인 채로 당월로 바뀌었을 경우 selectedMonth 값을 2월의 마지막 날짜(29일 혹은 28일)로 업데이트 해주어야 함
             guard let year = Int(selectedYear) else { return }
             dayType = isLeapYear(year) ? 2 : 3
+            if day == 31 || day == 30 {
+                selectedDay = String("\(dateViewModel.dayList[dayType].last!)")
+            }
         case .apr, .june, .sep, .nov:
+            // 4, 6, 9, 11월은 30일
+            // 31일인 채로 당월로 바뀌었을 경우 selectedMonth 값을 4, 6, 9, 11월의 마지막 날짜(30일)로 업데이트해주어야 함.
+            guard let day = Int(selectedDay) else { return }
             dayType = 1
+            if day == 31 {
+                selectedDay = String("\(dateViewModel.dayList[dayType].last!)")
+            }
         }
         dayPickerView.reloadComponent(0)
     }

--- a/everyBody/everyBody-iOS/Source/Camera/Views/NBDatePicker.swift
+++ b/everyBody/everyBody-iOS/Source/Camera/Views/NBDatePicker.swift
@@ -1,0 +1,231 @@
+//
+//  NBDatePicker.swift
+//  everyBody-iOS
+//
+//  Created by 윤예지 on 2021/11/19.
+//
+
+import UIKit
+
+import Then
+import SnapKit
+import RxSwift
+
+protocol DatePickerDelegate: AnyObject {
+    func pickerViewSelected(_ dataArray: [String])
+}
+
+class NBDatePicker: UIView {
+    
+    // MARK: - Properties
+    
+    private let disposeBag = DisposeBag()
+    private let dateViewModel = DateViewModel()
+    private lazy var selectedYear: String = ""
+    private lazy var selectedMonth: String = ""
+    private lazy var selectedDay: String = ""
+    private lazy var selectedHour: String = ""
+    private lazy var selectedMinute: String = ""
+    private lazy var dayType: Int = 0 // 0일때 31일, 1일때 30일, 2일때 29일, 3일때 28일
+    
+    weak var delegate: DatePickerDelegate?
+    
+    // MARK: - UI Components
+    
+    private lazy var yearPickerView = UIPickerView()
+    private lazy var monthPickerView = UIPickerView()
+    private lazy var dayPickerView = UIPickerView()
+    private lazy var hourPickerView = UIPickerView()
+    private lazy var minutePickerView = UIPickerView()
+    private var pickerViewList: [UIPickerView] {
+        return [yearPickerView, monthPickerView, dayPickerView, hourPickerView, minutePickerView]
+    }
+    private let colonLabel = UILabel().then {
+        $0.font = .nbFont(type: .body2SemiBold)
+        $0.text = ":"
+    }
+    
+    // MARK: - initalizer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setContraint()
+        setPickerViewDelegate()
+        removePickerViewBackgroundColor()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Methods
+    
+    private func setPickerViewDelegate() {
+        pickerViewList.forEach { pickerView in
+            pickerView.delegate = self
+            pickerView.dataSource = self
+        }
+    }
+    
+    private func setContraint() {
+        addSubviews(yearPickerView, monthPickerView, dayPickerView, hourPickerView, minutePickerView, colonLabel)
+        
+        yearPickerView.snp.makeConstraints {
+            $0.top.leading.equalToSuperview()
+            $0.width.equalTo(100)
+            $0.height.equalTo(95)
+        }
+        
+        var previousPickerView = yearPickerView
+        for pickerView in pickerViewList[1..<pickerViewList.count] {
+            pickerView.snp.makeConstraints {
+                $0.top.equalToSuperview()
+                $0.leading.equalTo(previousPickerView.snp.trailing).offset(-15)
+                $0.width.equalTo(65)
+                $0.height.equalTo(95)
+            }
+            previousPickerView = pickerView
+        }
+        
+        colonLabel.snp.makeConstraints {
+            $0.leading.equalTo(hourPickerView.snp.trailing).offset(-7)
+            $0.top.equalTo(36)
+        }
+    }
+    
+    private func removePickerViewBackgroundColor() {
+        DispatchQueue.main.async { [self] in
+            [yearPickerView, monthPickerView, dayPickerView, hourPickerView, minutePickerView]
+                .forEach { picker in
+                    picker.subviews[1].backgroundColor = .clear
+                }
+        }
+    }
+    
+    private func setDayDate(with month: Month) {
+        switch month {
+        case .jan, .mar, .may, .july, .aug, .oct, .dec:
+            dayType = 0
+        case .feb:
+            guard let year = Int(selectedYear) else { return }
+            dayType = isLeapYear(year) ? 2 : 3
+        case .apr, .june, .sep, .nov:
+            dayType = 1
+        }
+        dayPickerView.reloadComponent(0)
+    }
+    
+    private func isLeapYear(_ year: Int) -> Bool {
+        if year % 400 == 0 {
+            return true
+        } else if year % 100 != 0 && year % 4 == 0 {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    func setMetaDataTime(dataArray: [String]) {
+        yearPickerView.selectRow(Int(dataArray[0])! - 2000, inComponent: 0, animated: true)
+        monthPickerView.selectRow(Int(dataArray[1])! - 1, inComponent: 0, animated: true)
+        dayPickerView.selectRow(Int(dataArray[2])! - 1, inComponent: 0, animated: true)
+        hourPickerView.selectRow(Int(dataArray[3])! - 1, inComponent: 0, animated: true)
+        minutePickerView.selectRow(Int(dataArray[4])!, inComponent: 0, animated: true)
+        
+        selectedYear = dataArray[0]
+        selectedMonth = dataArray[1]
+        selectedDay = dataArray[2]
+        selectedHour = dataArray[3]
+        selectedMinute = dataArray[4]
+        delegate?.pickerViewSelected([selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute])
+    }
+    
+    func setCurrnetTime() {
+        let date = AppDate()
+        
+        yearPickerView.selectRow(date.getYear() - 2000, inComponent: 0, animated: true)
+        monthPickerView.selectRow(date.getMonth() - 1, inComponent: 0, animated: true)
+        dayPickerView.selectRow(date.getDay() - 1, inComponent: 0, animated: true)
+        hourPickerView.selectRow(date.getHour() - 1, inComponent: 0, animated: true)
+        minutePickerView.selectRow(date.getMinute(), inComponent: 0, animated: true)
+        
+        selectedYear = date.getYearToString()
+        selectedMonth = date.getMonthToString()
+        selectedDay = date.getDayToString()
+        selectedHour = date.getHourToString()
+        selectedMinute = date.getMinuteToString()
+        delegate?.pickerViewSelected([selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute])
+    }
+}
+
+extension NBDatePicker: UIPickerViewDelegate {
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        switch pickerView {
+        case yearPickerView:
+            selectedYear = dateViewModel.yearList[row]
+        case monthPickerView:
+            setDayDate(with: dateViewModel.monthList[row])
+            selectedMonth = dateViewModel.monthList[row].toNumberMonth()
+        case dayPickerView:
+            selectedDay = dateViewModel.dayList[dayType][row].convertTo2Digit()
+        case hourPickerView:
+            selectedHour = dateViewModel.hourList[row].convertTo2Digit()
+        case minutePickerView:
+            selectedMinute = dateViewModel.minuteList[row].convertTo2Digit()
+        default:
+            return
+        }
+        delegate?.pickerViewSelected([selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute])
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        let label = UILabel()
+        label.font = .nbFont(type: .body2SemiBold)
+        
+        switch pickerView {
+        case yearPickerView:
+            label.text = dateViewModel.yearList[row]
+        case monthPickerView:
+            label.text = dateViewModel.monthList[row].toString()
+        case dayPickerView:
+            label.text = dateViewModel.dayList[dayType][row]
+        case hourPickerView:
+            label.text = dateViewModel.hourList[row]
+        case minutePickerView:
+            label.text = dateViewModel.minuteList[row]
+        default:
+            return label
+        }
+        
+        label.textAlignment = .center
+        return label
+    }
+    
+}
+
+extension NBDatePicker: UIPickerViewDataSource {
+    
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        switch pickerView {
+        case yearPickerView:
+            return dateViewModel.yearList.count
+        case monthPickerView:
+            return dateViewModel.monthList.count
+        case dayPickerView:
+            return dateViewModel.dayList[dayType].count
+        case hourPickerView:
+            return dateViewModel.hourList.count
+        case minutePickerView:
+            return dateViewModel.minuteList.count
+        default:
+            return 0
+        }
+    }
+    
+}

--- a/everyBody/everyBody-iOS/Source/Extensions/String+2DigitFormat.swift
+++ b/everyBody/everyBody-iOS/Source/Extensions/String+2DigitFormat.swift
@@ -1,0 +1,20 @@
+//
+//  String+2DigitFormat.swift
+//  everyBody-iOS
+//
+//  Created by 윤예지 on 2021/11/20.
+//
+
+import Foundation
+
+extension String {
+    
+    func convertTo2Digit() -> String {
+        if self.count < 2 {
+            return "0\(self)"
+        } else {
+            return self
+        }
+    }
+    
+}


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
- 내장 피커뷰로는 디자인을 반영할 수가 없어서 pickerView 5개를 이어붙여서 custom date picker view를 만들었습니다
- 사진 시간, 현재 시간을 누를 때는 피커뷰들이 비활성화됩니다
- 피커 값 변경 시 이미지에 해당 값이 반영됩니다
- 각 month 마다 31, 30, 29, 28일등 day 케이스가 4가지로 분류되어있고, 2월의 경우에는 별도의 윤년 계산을 합니다

#### 📌 변경 사항
변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요.

##### 📸 ScreenShot

https://user-images.githubusercontent.com/69361613/142704275-e44db6ec-ac73-420b-a3e1-a5b38de8cda7.mp4

##### ✅ PR check list
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #17 

