### PR TITLE
#90 : panorama selected bug

### DIFF
--- a/Noonbody/Noonbody/Source/Presentation/Panorama/Cells/BottomCollectionViewCell.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Panorama/Cells/BottomCollectionViewCell.swift
@@ -14,21 +14,26 @@ class BottomCollectionViewCell: UICollectionViewCell {
     
     // MARK: - UIComponenets
     
-    var panoramaCellImage = UIImageView().then {
+    private var panoramaCellImage = UIImageView().then {
         $0.makeRounded(radius: 4)
         $0.contentMode = .scaleAspectFill
         $0.clipsToBounds = true
     }
-    var bottomView = UIView()
-    var tagView = UIView()
-    var tagLabel = UILabel().then {
+    private var bottomView = UIView()
+    private var tagView = UIView()
+    private var tagLabel = UILabel().then {
         $0.textColor = Asset.Color.gray50.color
         $0.textAlignment = .center
+        $0.font = .nbFont(ofSize: 10, weight: .bold, type: .pretendard)
     }
     
     // MARK: - Properties
-    
-    var index = 0
+
+    override var isSelected: Bool {
+        didSet {
+            isSelected ? transformToCenter() : transformToStandard()
+        }
+    }
     
     // MARK: - Initializer
     
@@ -81,7 +86,7 @@ class BottomCollectionViewCell: UICollectionViewCell {
         
         tagView.snp.makeConstraints {
             $0.top.bottom.equalTo(tagLabel).inset(-3)
-            $0.leading.trailing.equalTo(tagLabel).inset(-10)
+            $0.leading.trailing.equalTo(tagLabel).inset(-8)
         }
         
     }
@@ -90,20 +95,24 @@ class BottomCollectionViewCell: UICollectionViewCell {
         panoramaCellImage.setImage(with: imageURL)
         tagLabel.text = "\(index+1)"
         tagLabel.sizeToFit()
+        
+        if index == 0 {
+            transformToCenter()
+        }
     }
     
     func transformToCenter() {
         tagView.backgroundColor = Asset.Color.keyPurple.color
         tagLabel.textColor = .white
         panoramaCellImage.makeRoundedWithBorder(radius: 4, color: Asset.Color.keyPurple.color.cgColor, borderWith: 2)
-        tagView.makeRoundedWithBorder(radius: tagView.frame.height/2, color: Asset.Color.keyPurple.color.cgColor, borderWith: 2)
+        tagView.makeRoundedWithBorder(radius: 10, color: Asset.Color.keyPurple.color.cgColor, borderWith: 2)
     }
     
     func transformToStandard() {
         tagView.backgroundColor = .clear
         tagLabel.textColor = Asset.Color.gray50.color
         panoramaCellImage.makeRoundedWithBorder(radius: 4, color: UIColor.clear.cgColor)
-        tagView.makeRoundedWithBorder(radius: tagView.frame.height/2, color: UIColor.clear.cgColor)
+        tagView.makeRoundedWithBorder(radius: 10, color: UIColor.clear.cgColor)
     }
     
 }

--- a/Noonbody/Noonbody/Source/Presentation/Panorama/Cells/BottomCollectionViewCell.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Panorama/Cells/BottomCollectionViewCell.swift
@@ -71,7 +71,8 @@ class BottomCollectionViewCell: UICollectionViewCell {
     
     private func setConstraints() {
         panoramaCellImage.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(1)
             $0.height.equalTo(contentView.frame.width * (4/3)).priority(999)
         }
         
@@ -95,10 +96,6 @@ class BottomCollectionViewCell: UICollectionViewCell {
         panoramaCellImage.setImage(with: imageURL)
         tagLabel.text = "\(index+1)"
         tagLabel.sizeToFit()
-        
-        if index == 0 {
-            transformToCenter()
-        }
     }
     
     func transformToCenter() {

--- a/Noonbody/Noonbody/Source/Presentation/Panorama/Extensions/PanoramaViewController+Extensions.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Panorama/Extensions/PanoramaViewController+Extensions.swift
@@ -7,10 +7,13 @@
 
 import UIKit
 
+let cellSpacing: CGFloat = 2
+
 extension PanoramaViewController: UICollectionViewDelegateFlowLayout {
+    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         if collectionView == bottomCollectionView {
-            return CGSize(width: collectionView.frame.height * 0.54 + 2, height: collectionView.frame.height )
+            return CGSize(width: collectionView.frame.height * 0.54 + cellSpacing, height: collectionView.frame.height )
         } else {
             let length =  Constant.Size.screenWidth
             let ratio = UIDevice.current.hasNotch ? (4.0/3.0) : (423/375)
@@ -20,10 +23,10 @@ extension PanoramaViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         if collectionView == bottomCollectionView {
-            let inset = (collectionView.frame.width - (2 + collectionView.frame.height * 0.54)) / 2
+            let inset = (collectionView.frame.width - (collectionView.frame.height * 0.54 + cellSpacing)) / 2
             return UIEdgeInsets(top: 0, left: inset, bottom: 0, right: inset)
         } else {
-            return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+            return .zero
         }
     }
     
@@ -59,7 +62,7 @@ extension PanoramaViewController: UICollectionViewDelegateFlowLayout {
         }
     }
     
-    func setCenterCell() {
+    private func moveCellToCenter() {
         let centerPoint = CGPoint(x: bottomCollectionView.contentOffset.x + bottomCollectionView.frame.midX, y: 100)
         if let indexPath = bottomCollectionView.indexPathForItem(at: centerPoint) {
             bottomCollectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
@@ -70,16 +73,16 @@ extension PanoramaViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        setCenterCell()
+        moveCellToCenter()
     }
     
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
-        setCenterCell()
+        moveCellToCenter()
     }
     
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         if !decelerate {
-            setCenterCell()
+            moveCellToCenter()
         }
     }
 }

--- a/Noonbody/Noonbody/Source/Presentation/Panorama/Extensions/PanoramaViewController+Extensions.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Panorama/Extensions/PanoramaViewController+Extensions.swift
@@ -20,7 +20,7 @@ extension PanoramaViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         if collectionView == bottomCollectionView {
-            let inset = (topCollectionView.frame.width - 48) / 2
+            let inset = (collectionView.frame.width - (2 + collectionView.frame.height * 0.54)) / 2
             return UIEdgeInsets(top: 0, left: inset, bottom: 0, right: inset)
         } else {
             return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
@@ -37,25 +37,21 @@ extension PanoramaViewController: UICollectionViewDelegateFlowLayout {
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if scrollView == bottomCollectionView {
-            let centerX = bottomCollectionView.frame.size.width / 2 + scrollView.contentOffset.x
-            let centerY = bottomCollectionView.frame.size.height / 2 + scrollView.contentOffset.y
-            let centerPoint = CGPoint(x: centerX, y: centerY)
+            let centerPoint = CGPoint(x: bottomCollectionView.contentOffset.x + bottomCollectionView.frame.midX, y: 100)
             
             if let indexPath = self.bottomCollectionView.indexPathForItem(at: centerPoint), self.centerCell == nil {
-                /// 중간 좌표에 있는 셀이 있을 때, 센터 셀이 nil이라면 그 아이템을 얘를 센터 셀에 넣어주고 함수 실행
                 self.centerCell = self.bottomCollectionView.cellForItem(at: indexPath) as? BottomCollectionViewCell
                 self.centerCell?.transformToCenter()
                 topCollectionView.selectItem(at: indexPath, animated: false, scrollPosition: .centeredHorizontally)
                 tagSelectedIdx = indexPath
             } else if self.centerCell == nil {
-                /// 중간에 걸려있는 인덱스가 없는데 센터 셀이 비어있을 때, itemspacing 사이에 걸려있는 상황
                 centerCell?.transformToStandard()
+                bottomCollectionView.scrollToItem(at: tagSelectedIdx, at: .centeredHorizontally, animated: true)
             }
             
             if let cell = centerCell {
                 let offsetX = centerPoint.x - cell.center.x
                 if offsetX < -cell.frame.width/2 || offsetX > cell.frame.width/2 {
-                    /// 중간에 있던 셀이 좌표를 벗어나면 nil로 만들어주고 원래 상태로 돌아가는 함수 실행
                     cell.transformToStandard()
                     self.centerCell = nil
                 }
@@ -63,8 +59,28 @@ extension PanoramaViewController: UICollectionViewDelegateFlowLayout {
         }
     }
     
+    func setCenterCell() {
+        let centerPoint = CGPoint(x: bottomCollectionView.contentOffset.x + bottomCollectionView.frame.midX, y: 100)
+        if let indexPath = bottomCollectionView.indexPathForItem(at: centerPoint) {
+            bottomCollectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+            topCollectionView.selectItem(at: indexPath, animated: false, scrollPosition: .centeredHorizontally)
+            self.centerCell = self.bottomCollectionView.cellForItem(at: indexPath) as? BottomCollectionViewCell
+            self.centerCell?.transformToCenter()
+        }
+    }
+    
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        bottomCollectionView.scrollToItem(at: tagSelectedIdx, at: .centeredHorizontally, animated: false)
+        setCenterCell()
+    }
+    
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        setCenterCell()
+    }
+    
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        if !decelerate {
+            setCenterCell()
+        }
     }
 }
 
@@ -96,11 +112,13 @@ extension PanoramaViewController: UICollectionViewDataSource {
         return cell
     }
     
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        return collectionView == topCollectionView ? true : false
+    }
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        if indexPath.row == 0 {
-            cameraButtonDidTap()
-        } else if collectionView == topCollectionView && editMode {
-            deleteData.append(bodyPartData[indexPath.row-1].id)
+        if collectionView == topCollectionView && editMode {
+            indexPath.row == 0 ? cameraButtonDidTap() : deleteData.append(bodyPartData[indexPath.row-1].id)
         }
     }
     

--- a/Noonbody/Noonbody/Source/Presentation/Panorama/Extensions/PanoramaViewController+Extensions.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Panorama/Extensions/PanoramaViewController+Extensions.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-let cellSpacing: CGFloat = 2
-
 extension PanoramaViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
@@ -25,9 +23,8 @@ extension PanoramaViewController: UICollectionViewDelegateFlowLayout {
         if collectionView == bottomCollectionView {
             let inset = (collectionView.frame.width - (collectionView.frame.height * 0.54 + cellSpacing)) / 2
             return UIEdgeInsets(top: 0, left: inset, bottom: 0, right: inset)
-        } else {
-            return .zero
         }
+        return .zero
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {

--- a/Noonbody/Noonbody/Source/Presentation/Panorama/Extensions/PanoramaViewController+Extensions.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Panorama/Extensions/PanoramaViewController+Extensions.swift
@@ -10,7 +10,7 @@ import UIKit
 extension PanoramaViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         if collectionView == bottomCollectionView {
-            return CGSize(width: collectionView.frame.height * 0.54, height: collectionView.frame.height )
+            return CGSize(width: collectionView.frame.height * 0.54 + 2, height: collectionView.frame.height )
         } else {
             let length =  Constant.Size.screenWidth
             let ratio = UIDevice.current.hasNotch ? (4.0/3.0) : (423/375)
@@ -28,7 +28,7 @@ extension PanoramaViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return 2
+        return collectionView == topCollectionView ? 2 : 0
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {

--- a/Noonbody/Noonbody/Source/Presentation/Panorama/ViewControllers/PanoramaViewController.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Panorama/ViewControllers/PanoramaViewController.swift
@@ -77,6 +77,7 @@ class PanoramaViewController: BaseViewController {
             setHide()
             reloadCollectionView()
             editMode ? initEditNavigationBar() : initNavigationBar()
+            initBottomCollectionView()
         }
     }
     
@@ -109,7 +110,13 @@ class PanoramaViewController: BaseViewController {
         $0.scrollDirection = .horizontal
     }
     
-    var tagSelectedIdx = IndexPath(row: 0, section: 0)
+    var tagSelectedIdx = IndexPath(row: 0, section: 0) {
+        didSet {
+            if tagSelectedIdx.row > 0 {
+                bottomCollectionView.deselectItem(at: IndexPath(item: 0, section: 0), animated: false)
+            }
+        }
+    }
     var centerCell: BottomCollectionViewCell?
     
     // MARK: - View Life Cycle
@@ -223,8 +230,10 @@ class PanoramaViewController: BaseViewController {
     }
     
     private func initBottomCollectionView() {
-        let selectedIndexPath = IndexPath(item: 0, section: 0)
-        bottomCollectionView.selectItem(at: selectedIndexPath, animated: false, scrollPosition: .centeredHorizontally)
+        if !bodyPartData.isEmpty {
+            let selectedIndexPath = IndexPath(item: 0, section: 0)
+            bottomCollectionView.selectItem(at: selectedIndexPath, animated: false, scrollPosition: .centeredHorizontally)
+        }
     }
     
     private func switchPanoramaMode() {

--- a/Noonbody/Noonbody/Source/Presentation/Panorama/ViewControllers/PanoramaViewController.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Panorama/ViewControllers/PanoramaViewController.swift
@@ -61,6 +61,7 @@ class PanoramaViewController: BaseViewController {
     
     // MARK: - Properties
     
+    let cellSpacing: CGFloat = 2
     private let viewModel = PanoramaViewModel(panoramaUseCase: DefaultPanoramaUseCase(panoramaRepository: DefaultPanoramaRepository()))
     private var popupViewController = PopUpViewController(type: .delete)
     private var bodyPart = 0

--- a/Noonbody/Noonbody/Source/Presentation/Panorama/ViewControllers/PanoramaViewController.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Panorama/ViewControllers/PanoramaViewController.swift
@@ -36,14 +36,14 @@ class PanoramaViewController: BaseViewController {
     }
     
     var bottomCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout()).then {
+        $0.register(BottomCollectionViewCell.self)
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
+        $0.collectionViewLayout = layout
         $0.bounces = false
-        $0.register(BottomCollectionViewCell.self)
         $0.backgroundColor = .white
         $0.showsHorizontalScrollIndicator = false
         $0.allowsMultipleSelection = false
-        $0.collectionViewLayout = layout
         $0.setContentHuggingPriority(.defaultLow, for: .vertical)
     }
     
@@ -77,9 +77,6 @@ class PanoramaViewController: BaseViewController {
             setHide()
             reloadCollectionView()
             editMode ? initEditNavigationBar() : initNavigationBar()
-            if !bodyPartData.isEmpty {
-                bottomCollectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .centeredHorizontally, animated: true)
-            }
         }
     }
     
@@ -138,7 +135,7 @@ class PanoramaViewController: BaseViewController {
         bind()
     }
     
-    override func viewDidAppear(_ animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         initBottomCollectionView()
     }
     
@@ -226,8 +223,8 @@ class PanoramaViewController: BaseViewController {
     }
     
     private func initBottomCollectionView() {
-        centerCell = bottomCollectionView.cellForItem(at: tagSelectedIdx) as? BottomCollectionViewCell
-        centerCell?.transformToCenter()
+        let selectedIndexPath = IndexPath(item: 0, section: 0)
+        bottomCollectionView.selectItem(at: selectedIndexPath, animated: false, scrollPosition: .centeredHorizontally)
     }
     
     private func switchPanoramaMode() {
@@ -238,9 +235,6 @@ class PanoramaViewController: BaseViewController {
             topCollectionView.setCollectionViewLayout(horizontalFlowLayout, animated: false)
             bottomCollectionView.isHidden = false
         }
-        
-        self.view.layoutIfNeeded()
-        bottomCollectionView.scrollToItem(at: tagSelectedIdx, at: .centeredHorizontally, animated: true)
     }
     
     func reloadCollectionView() {
@@ -248,7 +242,7 @@ class PanoramaViewController: BaseViewController {
         bottomCollectionView.reloadData()
     }
     
-    func setHide(){
+    func setHide() {
         emptyView.isHidden = bodyPartData.isEmpty && !editMode ? false : true
         gridButton.isHidden = bodyPartData.isEmpty || editMode ? true : false
     }


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약

- 스크롤이 여러 방식으로 멈췄을 때 호출되는 `scrollViewDidEndDecelerating` `scrollViewDidEndScrollingAnimation` `scrollViewDidEndDragging` 이 메서드들에 센터셀이 centeredHorizontally 스크롤되는 함수를 호출해서 카카오톡 여러장 보내기 했을 때 처럼 애니메이션되도록 약간 수정
- 묘하게 셀이 중앙에 안맞아서 레이아웃 수정
- 원래는 bottomCollectionView가 reload될 때 첫번째 셀이 선택되어있지 않았는데, 첫번째 셀이 선택되도록 초기세팅을 했음



뷰 설계를 너무 복잡하게 짜놔서 스프린트 내에 가능하다면
- [ ] body part를 왔다갔다할 때 선택되어있던 사진 인덱스가 유지되도록
- [ ] 그리드모드를 on off 할 때 선택되어 있던 사진 인덱스가 유지되도록



#### 📌 변경 사항
변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요.

##### 📸 ScreenShot
https://user-images.githubusercontent.com/70168249/148702995-b1d10373-6c5d-48de-9f48-1ffe7a61731c.mp4


##### ✅ PR check list
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #90

