### PR TITLE
#111: 동영상 저장 뷰에서 삭제해도 ImageList 갱신되지 않는 버그 픽스

### DIFF
--- a/Noonbody/Noonbody/Source/Presentation/Video/ViewController/VideoEditViewController.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Video/ViewController/VideoEditViewController.swift
@@ -346,7 +346,9 @@ extension VideoEditViewController: UICollectionViewDelegateFlowLayout {
                         didSelectItemAt indexPath: IndexPath) {
         isSelectedEvent = true
         guard let cell = collectionView.cellForItem(at: indexPath) as? PreviewCollectionViewCell else { return }
+        centerCell?.setUnselectedUI()
         centerCell = cell
+        cell.setSelectedUI()
         collectionView.setContentOffset(CGPoint(x: cell.frame.minX - (collectionView.frame.width / 2 - cellWidth / 2),
                                                 y: 0.0),
                                         animated: true)


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
동영상 뷰에서 UI 상에서 이미지를 제거해도 실제 데이터에선 남아있는 버그가 있었습니다.
Subject를 별도로 선언해서 이미지 리스트가 바뀔 때마다 onNext로 이벤트를 방출하는 방식으로 해당 버그를 고쳤습니다

#### 📌 변경 사항
변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요.

##### 📸 ScreenShot

##### ✅ PR check list
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #111 

