### PR TITLE
#117: 동영상 편집 뷰 버그 fix

### DIFF
--- a/Noonbody/Noonbody.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Noonbody/Noonbody.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,7 +105,7 @@
         "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
         "state": {
           "branch": "master",
-          "revision": "96fa532b92085891e00bab6c069f3193a1e5bcc4",
+          "revision": "cb6bf4e49f6b55cf7da6e602e6d66fadc3137ed1",
           "version": null
         }
       },
@@ -152,6 +152,15 @@
           "branch": null,
           "revision": "e29e65a58c2f670677d17df9a18e846b87e78592",
           "version": "4.0.2"
+        }
+      },
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift",
+        "state": {
+          "branch": null,
+          "revision": "7c17a6ccca06b5c107cfa4284e634562ddaf5951",
+          "version": "6.2.0"
         }
       },
       {

--- a/Noonbody/Noonbody/Source/Presentation/Video/ViewController/VideoEditViewController.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Video/ViewController/VideoEditViewController.swift
@@ -114,7 +114,6 @@ class VideoEditViewController: BaseViewController {
                 popUp.titleLabel.text = "비디오 저장 중 ...0%"
                 popUp.descriptionLabel.text = "눈바디 영상이 만들어지고 있어요!\n앱을 종료하거나 기기를 잠그지 마세요."
                 self.present(popUp, animated: true, completion: nil)
-
             })
             .disposed(by: disposeBag)
         

--- a/Noonbody/Noonbody/Source/Presentation/Video/ViewModel/VideoViewModel.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Video/ViewModel/VideoViewModel.swift
@@ -26,7 +26,7 @@ final class VideoViewModel {
 
     var imageList: [ImageInfo]
     var backingList: [(image: ImageInfo, index: Int)] = []
-    var imageSubject = PublishSubject<[ImageInfo]>()
+    var imageSubject = BehaviorSubject<[ImageInfo]>(value: [])
     let videoUsecase: VideoUseCase
     
     init(imageList: [ImageInfo], videoUsecase: VideoUseCase) {
@@ -51,7 +51,7 @@ final class VideoViewModel {
         let response =
             input.saveButtonControlEvent
             .withLatestFrom(imageSubject)
-            .map({ imageList in
+            .map({ imageList -> VideoRequestModel in
                 let imageKeys = imageList.map { $0.imageKey }
                 return VideoRequestModel(keys: imageKeys)
             })


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
동영상 저장에서 편집 작업없이 바로 비디오 저장을 누르면 request가 가지 않는 현상이 있었습니다.
PublishSubject로 타입을 선언해놓고 onNext 이벤트를 구독 이전에 방출해주어서 생긴 문제였고,
BehaviorSubject를 사용해서 이전의 이벤트를 받아올 수 있도록 변경하였습니다

#### 📌 변경 사항
변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요.

##### 📸 ScreenShot

##### ✅ PR check list
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #117 
