### PR TITLE
#179: background에서 foreground 진입시 생체인증 추가, 잠금해제 팝업 로직 수정

### DIFF
--- a/Noonbody/Noonbody/Resource/Support/SceneDelegate.swift
+++ b/Noonbody/Noonbody/Resource/Support/SceneDelegate.swift
@@ -12,6 +12,7 @@ import Siren
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    private var appSwitcherModeImageView = UIImageView()
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
@@ -47,16 +48,28 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        appSwitcherModeImageView.removeFromSuperview()
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
+        if UserManager.biometricAuthentication {
+            setupAppSwitcherMode()
+        }
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        if UserManager.biometricAuthentication {
+            switch scene.activationState {
+            case .background: // 한번 백그라운드에 갔다온 경우, 다시 생체인증 요구
+                evaluateAuthentication()
+            default:
+                break
+            }
+        }
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
@@ -68,4 +81,47 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
 
+}
+
+extension SceneDelegate {
+    
+    private func evaluateAuthentication() {
+        LocalAuthenticationService.shared.evaluateAuthentication { response, error in
+            DispatchQueue.main.async {
+                if response {
+                    self.window?.rootViewController?.presentedViewController?.dismiss(animated: false)
+                } else if error != nil {
+                    let popUp = AuthenticationPopupViewController()
+                    popUp.delegate = self
+                    popUp.modalTransitionStyle = .crossDissolve
+                    popUp.modalPresentationStyle = .overFullScreen
+                    self.window?.rootViewController?.present(popUp, animated: false)
+                }
+            }
+        }
+    }
+    
+    private func setupAppSwitcherMode() {
+        guard let window = window else { return }
+        appSwitcherModeImageView = UIImageView(frame: window.frame)
+        appSwitcherModeImageView.image = Asset.Image.logo.image
+        appSwitcherModeImageView.contentMode = .center
+        appSwitcherModeImageView.backgroundColor = Asset.Color.keyPurple.color
+        window.addSubview(appSwitcherModeImageView)
+    }
+    
+}
+
+extension SceneDelegate: PopUpActionProtocol {
+    
+    func cancelButtonDidTap(_ button: UIButton) {
+        LocalAuthenticationService.shared.evaluateAuthentication { response, _ in
+            DispatchQueue.main.async {
+                if response {
+                    self.window?.rootViewController?.presentedViewController?.dismiss(animated: false)
+                }
+            }
+        }
+    }
+    
 }

--- a/Noonbody/Noonbody/Source/Presentation/Launch/ViewController/LaunchScreenViewController.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Launch/ViewController/LaunchScreenViewController.swift
@@ -128,6 +128,7 @@ class LaunchScreenViewController: UIViewController {
     
     private func presentToAuthenticationPopup() {
         let popUp = AuthenticationPopupViewController()
+        popUp.delegate = self
         popUp.modalTransitionStyle = .crossDissolve
         popUp.modalPresentationStyle = .overFullScreen
         self.present(popUp, animated: false)
@@ -185,6 +186,21 @@ class LaunchScreenViewController: UIViewController {
                     self.pushToHomeViewController()
                 } else if error != nil {
                     self.presentToAuthenticationPopup()
+                }
+            }
+        }
+    }
+    
+}
+
+extension LaunchScreenViewController: PopUpActionProtocol {
+    
+    func cancelButtonDidTap(_ button: UIButton) {
+        LocalAuthenticationService.shared.evaluateAuthentication { response, error in
+            DispatchQueue.main.async {
+                if response {
+                    self.dismiss(animated: false)
+                    self.pushToHomeViewController()
                 }
             }
         }

--- a/Noonbody/Noonbody/Source/Presentation/Preferences/Cells/ProfileTableViewCell.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Preferences/Cells/ProfileTableViewCell.swift
@@ -174,7 +174,10 @@ extension ProfileTableViewCell: NBSwitchDelegate {
             if isOn { // 생체인증 on
                 LocalAuthenticationService.shared.evaluateAuthentication { response, error in
                     UserManager.biometricAuthentication = response
-                    if error != nil { self.presentToFailedPopupViewcontroller()
+                    if error != nil {
+                        DispatchQueue.main.async {
+                        self.switchButton.isOn = false  
+                        }
                     }
                 }
             } else { // 생체인증 off

--- a/Noonbody/Noonbody/Source/Presentation/Preferences/ViewControllers/AuthenticationPopupViewController.swift
+++ b/Noonbody/Noonbody/Source/Presentation/Preferences/ViewControllers/AuthenticationPopupViewController.swift
@@ -12,6 +12,8 @@ import Then
 
 class AuthenticationPopupViewController: BaseViewController {
     
+    // MARK: - UI Components
+    
     private var biometricImage = UIImageView().then {
         $0.image = Asset.Image.faceID.image
     }
@@ -36,13 +38,20 @@ class AuthenticationPopupViewController: BaseViewController {
         $0.isEnabled = true
         $0.addTarget(self, action: #selector(confirmButtonDidTap), for: .touchUpInside)
     }
+    
+    // MARK: - Properties
+    
+    var delegate: PopUpActionProtocol?
 
     // MARK: - Life Cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViewHierarchy()
         setupConstraints()
     }
+    
+    // MARK: - Methods
     
     private func setupViewHierarchy() {
         view.addSubviews(biometricImage, failedLabel, descriptionLabel, confirmButton)
@@ -69,8 +78,8 @@ class AuthenticationPopupViewController: BaseViewController {
             $0.height.equalTo(56)
         }
     }
-
+    
     @objc func confirmButtonDidTap() {
-        self.dismiss(animated: false)
+        delegate?.cancelButtonDidTap(confirmButton)
     }
 }


### PR DESCRIPTION
## 🏋️‍♀️ PR 요약
해당 pr에서 작업한 내역을 적어주세요.
- [x] background에서 foreground 진입시에 생체인증 추가적으로 받음
- [x] 기존에 잠금해제를 누르면 그냥 dismiss되었었는데 다시 인증 받는 로직으로 수정힘

#### 📌 변경 사항
변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요.

##### 📸 ScreenShot

https://user-images.githubusercontent.com/70168249/189332581-38edda13-9922-452b-a70c-bed0b3d6aa6d.mov



##### ✅ PR check list
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```

#### Linked Issue
close #179 

